### PR TITLE
lookupGE: fix docs

### DIFF
--- a/Data/IntervalMap/Generic/Base.hs
+++ b/Data/IntervalMap/Generic/Base.hs
@@ -429,7 +429,7 @@ lookupLE k m = go m
                                        EQ -> Just (key,v)
                                        GT -> go1 key v r
 
--- | /O(log n)/. Find the smallest key larger than the given one
+-- | /O(log n)/. Find the smallest key equal to or larger than the given one
 -- and return it along with its value.
 lookupGE :: (Ord k) => k -> IntervalMap k v -> Maybe (k,v)
 lookupGE k m = go m


### PR DESCRIPTION
I assume "GE" stands for "greater than or equal to", so I've corrected the documentation of `lookupGE` to mirror that of `lookupLE` (which _does_ include "equal to").