### PR TITLE
Fix benchmarks build error with ghc 9.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /cabal.project.local
 /doc/
 bench*.html
+.aider*

--- a/IntervalMap.cabal
+++ b/IntervalMap.cabal
@@ -1,5 +1,5 @@
 Name:                IntervalMap
-Version:             0.6.2.3
+Version:             0.6.2.4
 Stability:           experimental
 Synopsis:            Containers for intervals, with efficient search.
 Homepage:            https://www.chr-breitkopf.de/comp/IntervalMap
@@ -12,7 +12,7 @@ Copyright:           2011-2026 Christoph Breitkopf
 Category:            Data
 Build-type:          Simple
 Cabal-version:       >= 1.10
-Tested-With:         GHC ==8.0.2, GHC ==8.2.1, GHC ==8.4.1, GHC ==8.6.5, GHC ==8.8.3, GHC ==9.0.2, GHC ==9.6.7
+Tested-With:         GHC ==8.0.2, GHC ==8.2.1, GHC ==8.4.1, GHC ==8.6.5, GHC ==8.8.3, GHC ==9.0.2, GHC ==9.6.7, GHC ==9.12.4
 Description:
                      Ordered containers of intervals, with efficient search
                      for all keys containing a point or overlapping an interval.

--- a/bench/RBColorIntBase.hs
+++ b/bench/RBColorIntBase.hs
@@ -64,7 +64,7 @@ module RBColorIntBase (
 
             ) where
 
-import Prelude hiding (null, lookup, map, filter, foldr, foldl)
+import Prelude hiding (Foldable(..), lookup, map, filter)
 import Data.Bits (shiftR, (.&.))
 import Data.Monoid (Monoid(..))
 import Control.Applicative (Applicative(..), (<$>))
@@ -423,7 +423,7 @@ data T2 a b = T2 !a !b
 fromDistinctAscList :: (Interval k e) => [(k,v)] -> IntervalMap k v
 -- exactly 2^n-1 items have height n. They can be all black
 -- from 2^n - 2^n-2 items have height n+1. The lowest "row" should be red.
-fromDistinctAscList lyst = case h (length lyst) lyst of
+fromDistinctAscList lyst = case h (L.length lyst) lyst of
                              (T2 result []) -> result
                              _ -> error "fromDistinctAscList: list not fully consumed"
   where

--- a/changelog
+++ b/changelog
@@ -1,3 +1,4 @@
+0.6.2.4  Fix build error of benchmarks with ghc 9.12
 0.6.2.3  Fix benchmark broken by fingertree adding its own NFData instance
 0.6.2.2  Remove SegmentTree from benchmarks because it does not compile with current ghc/cabal
 0.6.2.1  Future-proof against potential Prelude.foldl'


### PR DESCRIPTION
The changes in PR #10 made the library and test code compatible with newer GHC versions, but did not include the benchmarks. This PR applies the same changes, hiding Foldable from the prelude import, to the benchmarks.
Fixes #11 